### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit, :create, :update]
-  before_action :set_item, only: [:edit, :show, :update]
-  before_action :move_to_show, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :edit, :create, :update, :destroy]
+  before_action :set_item, only: [:edit, :show, :update, :destroy]
+  before_action :move_to_show, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.includes(:user).order(id: 'DESC')
@@ -34,6 +34,12 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    end
+  end
+
   private
 
   def item_params
@@ -42,7 +48,9 @@ class ItemsController < ApplicationController
   end
 
   def move_to_show
-    redirect_to root_path unless current_user.id == @item.user.id
+    unless current_user.id == @item.user.id
+        redirect_to root_path
+    end
   end
 
   def set_item

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,7 +37,10 @@ class ItemsController < ApplicationController
   def destroy
     if @item.destroy
       redirect_to root_path
+    else
+      render :show
     end
+
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if current_user == @item.user %>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
       <% else %>
         <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:new, :create, :index, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# What
商品削除機能の実装をするために修正箇所を依頼。

#Why
商品削除機能を実装するために。

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる画像
https://gyazo.com/80312b2ec5a5dff14b60cf4eeb093bdd
よろしくお願いします。